### PR TITLE
Fix the Check for New Commits

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -20,7 +20,7 @@ jobs:
       - id: should_run
         if: ${{ github.event_name == 'schedule' }}
         name: check that there have been commits since the last tag
-        run: test -z $(git rev-list $(git describe --tags --abbrev=0)..${{ github.sha }}) && echo "shouldRun=no" >> "$GITHUB_OUTPUT"
+        run: test -z $(git rev-list $(git describe --tags --abbrev=0)..${{ github.sha }} --max-count=1) && echo "shouldRun=no" >> "$GITHUB_OUTPUT"
   tag:
     needs: has_changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
When there have been multiple commits the test was failing because git rev-list lists each commit on a line breaking the bash test method. This ensures only one commit will be shown, which is all we care about anyway.