### PR TITLE
Improve list releases

### DIFF
--- a/lib/releaseList.js
+++ b/lib/releaseList.js
@@ -4,9 +4,7 @@ const github = require('./github.js');
 
 exports.releaseList = async (owner, repo) => {
   try {
-    return await github.paginate('GET /repos/:owner/:repo/releases', { owner, repo }, (response) =>
-      response.data.map((release) => release.name),
-    );
+    return await github.paginate('GET /repos/:owner/:repo/releases', { owner, repo });
   } catch (e) {
     console.error(`error unable to fetch releases: ${e}`);
     return [];

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
 functions:
   slack:
     handler: app.handler
+    timeout: 10
     events:
       - http:
           path: slack/events

--- a/src/ilios.js
+++ b/src/ilios.js
@@ -126,11 +126,17 @@ module.exports = class Home {
   }
 
   async getReleaseListBlocksFor(project, name) {
-    const releases = await releaseList('ilios', project);
+    let releases = await releaseList('ilios', project);
 
-    let list = releases.join('\n * ');
-    if (list.length > 2999) {
-      list = list.substr(0, 2000) + '\n\n *List Truncated at Maximum Length*';
+    const MAX_RELEASES_SHOWN = 25;
+
+    let list = releases.map((r) => `<${r.html_url}|${r.name}>`);
+    if (releases.length > MAX_RELEASES_SHOWN) {
+      list.splice(MAX_RELEASES_SHOWN);
+    }
+    list = list.join('\n * ');
+    if (releases.length > MAX_RELEASES_SHOWN) {
+      list += `\n\n *List Truncated*. See <https://github.com/ilios/${project}/releases|full list on Github>.`;
     }
 
     return [
@@ -138,7 +144,7 @@ module.exports = class Home {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `Releases For ${name}:\n * ` + list,
+          text: `Releases For *${name}*:\n * ` + list,
         },
       },
     ];


### PR DESCRIPTION
This improves the List Releases command twofold:

* Release names are now links to the releases
* Cutoff is now using release count (25) instead of raw string length, which means names don't get cut off due to arbitrary character count

Had to bump Serverless config timeout from 3s to 10s in order to accomodate.